### PR TITLE
fix call to determine_read_strand_params in PolyAReads

### DIFF
--- a/grit/files/reads.py
+++ b/grit/files/reads.py
@@ -957,7 +957,7 @@ class PolyAReads(Reads):
         if reverse_read_strand in ('auto', None):
             if ref_genes in([], None): 
                 raise ValueError, "Determining reverse_read_strand requires reference genes"
-            reverse_read_strand_params = Reads.determine_read_strand_param(
+            reverse_read_strand_params = determine_read_strand_params(
                 self, ref_genes, pairs_are_opp_strand, 'tes_exon',
                 300, 50 )
             assert 'stranded' in reverse_read_strand_params


### PR DESCRIPTION
This fixes the following crash with GRIT 2.0.5:

```
Traceback (most recent call last):
  File "/apps/gent/SL6/sandybridge/software/GRIT/2.0.5-intel-2016b-Python-2.7.12/bin/run_grit", line 4, in <module>
    __import__('pkg_resources').run_script('GRIT==2.0.5', 'run_grit')
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 719, in run_script
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 1511, in run_script
  File "/apps/gent/SL6/sandybridge/software/GRIT/2.0.5-intel-2016b-Python-2.7.12/lib/python2.7/site-packages/GRIT-2.0.5-py2.7-linux-x86_64.egg/EGG-INFO/scripts/run_grit", line 884, in <module>

  File "/apps/gent/SL6/sandybridge/software/GRIT/2.0.5-intel-2016b-Python-2.7.12/lib/python2.7/site-packages/GRIT-2.0.5-py2.7-linux-x86_64.egg/EGG-INFO/scripts/run_grit", line 777, in main

  File "/apps/gent/SL6/sandybridge/software/GRIT/2.0.5-intel-2016b-Python-2.7.12/lib/python2.7/site-packages/GRIT-2.0.5-py2.7-linux-x86_64.egg/EGG-INFO/scripts/run_grit", line 735, in iteritems

  File "/apps/gent/SL6/sandybridge/software/GRIT/2.0.5-intel-2016b-Python-2.7.12/lib/python2.7/site-packages/GRIT-2.0.5-py2.7-linux-x86_64.egg/EGG-INFO/scripts/run_grit", line 683, in _build_elements

  File "/apps/gent/SL6/sandybridge/software/GRIT/2.0.5-intel-2016b-Python-2.7.12/lib/python2.7/site-packages/GRIT-2.0.5-py2.7-linux-x86_64.egg/EGG-INFO/scripts/run_grit", line 364, in get_reads

  File "/apps/gent/SL6/sandybridge/software/GRIT/2.0.5-intel-2016b-Python-2.7.12/lib/python2.7/site-packages/GRIT-2.0.5-py2.7-linux-x86_64.egg/EGG-INFO/scripts/run_grit", line 351, in _load_polya_reads

  File "build/bdist.linux-x86_64/egg/grit/files/reads.py", line 960, in init
AttributeError: type object 'Reads' has no attribute 'determine_read_strand_param'
```
